### PR TITLE
Absolute/Field Drive Updates

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -48,4 +48,5 @@ public final class Constants {
     public static double winchSpeed = 0.50; // Clockwise = positive, holds funnel down in position
     public static double limit = 1;
   }
+  public static final boolean absoluteDrive = true;
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -54,7 +54,7 @@ public final class Constants {
     public static double winchSpeed = 0.50; // Clockwise = positive, holds funnel down in position
     public static double limit = 1;
   }
-  
+
   public enum ElevatorState {
     L1,
     L2,
@@ -72,6 +72,6 @@ public final class Constants {
   public static final Double elevatorP = 0.1;
   public static final Double elevatorI = 0.0;
   public static final Double elevatorD = 0.0;
-  
+
   public static final boolean absoluteDrive = true;
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -166,13 +166,21 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Default command, normal field-relative drive
     drive.setDefaultCommand(
-        DriveCommands.joystickDrive(
-            drive,
-            () -> -controller.getLeftY(),
-            () -> -controller.getLeftX(),
-            () -> -controller.getRightX()));
-
-    // Lock to 0° when A button is held
+        Constants.absoluteDrive
+            ? DriveCommands.joystickDriveAtAngle(
+                // Absolute Drive
+                drive,
+                () -> controller.getLeftX(),
+                () -> -controller.getLeftY(),
+                () -> -controller.getRightX(),
+                () -> controller.getRightY())
+            :
+            // Field Drive
+            DriveCommands.joystickDrive(
+                drive,
+                () -> -controller.getLeftY(),
+                () -> -controller.getLeftX(),
+                () -> -controller.getRightX()));
 
     JoystickButton a = new JoystickButton(driver, XboxController.Button.kA.value);
     a.onTrue(new LiftFunnel(funnel));
@@ -180,26 +188,18 @@ public class RobotContainer {
     JoystickButton b = new JoystickButton(driver, XboxController.Button.kB.value);
     b.onTrue(new LowerClimb(climb));
 
-    controller
-        .a()
-        .whileTrue(
-            DriveCommands.joystickDriveAtAngle(
-                drive,
-                () -> -controller.getLeftY(),
-                () -> -controller.getLeftX(),
-                () -> new Rotation2d()));
-
     // Switch to X pattern when X button is pressed
     controller.x().onTrue(Commands.runOnce(drive::stopWithX, drive));
 
     // Reset gyro / odometry
     final Runnable resetGyro =
-        Constants.currentMode == Constants.Mode.SIM
+        Constants.currentMode == Constants.Mode.SIM // this is an IF statement
+            // simulation
             ? () ->
                 drive.resetOdometry(
                     driveSimulation
                         .getSimulatedDriveTrainPose()) // reset odometry to actual robot pose during
-            // simulation
+            // real
             : () ->
                 drive.resetOdometry(
                     new Pose2d(drive.getPose().getTranslation(), new Rotation2d())); // zero gyro

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -337,10 +337,11 @@ public class DriveCommands {
                   getLinearVelocityFromJoysticks(xSupplier.getAsDouble(), ySupplier.getAsDouble());
 
               // Calculate angular speed
-              double omega = (headingMagnitude > 0.5) ? 
-                    angleController.calculate(
-                      drive.getRotation().getRadians(), rotationSupplier.get().getRadians())
-                    :0;
+              double omega =
+                  (headingMagnitude > 0.5)
+                      ? angleController.calculate(
+                          drive.getRotation().getRadians(), rotationSupplier.get().getRadians())
+                      : 0;
 
               // Convert to field relative speeds & send command
               ChassisSpeeds speeds =

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -322,8 +322,9 @@ public class Drive extends SubsystemBase implements Vision.VisionConsumer {
   public void resetOdometry(Pose2d pose) {
     resetSimulationPoseCallBack.accept(pose);
     poseEstimator.resetPosition(
-        rawGyroRotation.rotateBy(new Rotation2d(
-          Constants.absoluteDrive ? Math.PI/2 : Math.PI)), getModulePositions(), pose);
+        rawGyroRotation.rotateBy(new Rotation2d(Constants.absoluteDrive ? Math.PI / 2 : Math.PI)),
+        getModulePositions(),
+        pose);
   }
 
   /** Adds a new timestamped vision measurement. */

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -321,7 +321,9 @@ public class Drive extends SubsystemBase implements Vision.VisionConsumer {
   /** Resets the current odometry pose. */
   public void resetOdometry(Pose2d pose) {
     resetSimulationPoseCallBack.accept(pose);
-    poseEstimator.resetPosition(rawGyroRotation, getModulePositions(), pose);
+    poseEstimator.resetPosition(
+        rawGyroRotation.rotateBy(new Rotation2d(
+          Constants.absoluteDrive ? Math.PI/2 : Math.PI)), getModulePositions(), pose);
   }
 
   /** Adds a new timestamped vision measurement. */

--- a/src/main/java/frc/robot/subsystems/drive/GyroIONavX.java
+++ b/src/main/java/frc/robot/subsystems/drive/GyroIONavX.java
@@ -42,7 +42,7 @@ public class GyroIONavX implements GyroIO {
         yawTimestampQueue.stream().mapToDouble((Double value) -> value).toArray();
     inputs.odometryYawPositions =
         yawPositionQueue.stream()
-            .map((Double value) -> Rotation2d.fromDegrees(-value).unaryMinus())
+            .map((Double value) -> Rotation2d.fromDegrees(value).unaryMinus())
             .toArray(Rotation2d[]::new);
     yawTimestampQueue.clear();
     yawPositionQueue.clear();


### PR DESCRIPTION
**Added absolute drive capabilities and fixed bugs on field-relative drive**

DriveCommands.java
- New JoystickDriveAtAngle function within the default command for drive (Absolute Drive), can switch between Absolute and Field using the absoluteDrive constant
- New version takes 4 parameters (drive subsystem, DoubleSupplier X4)
- Copy pasted version with an added deadband and adjustments to rotation calculations using the extra DoubleSupplier (X and Y axis input of the right controller joystick)

Drive.java
- Line 325: Not sure how this caused the absolute drive gyro reset to work, suspect that this cancels out a separate gyro error by realigning it to be 90 degrees off. Works for now

GyroIONavX.java
- Changed a negative which made things not work (inverted the yaw readings)