### PR TITLE
Fix/minor cleanups

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -41,11 +41,13 @@ public final class Constants {
     public static double armSpeed = 0.50;
     public static double armEncoderUpperLimit = 1;
     public static double armEncoderLowerLimit = 4;
+    public static final int motorID = 81;
   }
 
   public static class Claw {
     public static double clawSpeed = 0.50;
     public static final int clawBeam = 4;
+    public static final int motorID = 71;
   }
 
   public static class Climb {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,6 +20,7 @@ import com.pathplanner.lib.auto.NamedCommands;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -77,6 +78,9 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+
+    DriverStation.silenceJoystickConnectionWarning(Constants.currentMode == Constants.Mode.SIM);
+
     ledLive = new LEDlive();
     elevator = new Elevator();
     switch (Constants.currentMode) {

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -15,7 +15,7 @@ import frc.robot.Constants;
 
 public class Arm extends SubsystemBase {
   /** Creates a new Arm. */
-  private TalonFX motorArm = new TalonFX(81);
+  private TalonFX motorArm = new TalonFX(Constants.Arm.motorID);
 
   private TalonFXSimState motorArmSim;
 

--- a/src/main/java/frc/robot/subsystems/Claw.java
+++ b/src/main/java/frc/robot/subsystems/Claw.java
@@ -15,7 +15,7 @@ import frc.robot.Constants;
 
 public class Claw extends SubsystemBase {
   /** Creates a new Claw. */
-  private TalonFX motorClaw = new TalonFX(71);
+  private TalonFX motorClaw = new TalonFX(Constants.Claw.motorID);
 
   private TalonFXSimState motorClawSim;
 


### PR DESCRIPTION
 *  Claw - do not use canivore, do put values on dashboard in sim.
    
*   If we put these numbers on the dashboard during similation, it
    produces errors like:
    
    CAN frame not received/too-stale. Check the CAN bus wiring,
        CAN bus utilization, and power to the device.
            talon fx 71 ("") Status Signal Position
    CAN frame not received/too-stale. Check the CAN bus wiring,
        CAN bus utilization, and power to the device.
            talon fx 71 ("") Status Signal Velocity
    Device firmware could not be retrieved. Check that the device is running
         v6 firmware, the device ID is correct, the specified CAN bus is correct,
         and the device is powered.
            talon fx 71 ("")

 *  Arm - Do not use a canivore, use the standard CAN.
    
    Minor cleanups there also.

*   Silence warnings about joysticks not plugged in.
    
    The repeated warnings are not useful and make reading output difficult.
