### PR TITLE
Add Strafe commands and bind to right and left trigger.

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -211,6 +211,17 @@ public class RobotContainer {
     driverController.x().onTrue(new LowerFunnel(funnel, climb));
     driverController.y().whileTrue(new LiftFunnel(funnel, climb));
 
+    driverController
+        .leftTrigger(0.1)
+        .whileTrue(
+            DriveCommands.strafe(drive, true, () -> driverController.getLeftTriggerAxis() * 0.5));
+    driverController
+        .rightTrigger(0.1)
+        .whileTrue(
+            DriveCommands.strafe(drive, false, () -> driverController.getRightTriggerAxis() * 0.5));
+
+    // driverController.rightBumper().whileTrue(DriveCommands.strafe(drive,false,() -> 0.1));
+
     // Switch to X pattern when X button is pressed
     driverController.leftBumper().onTrue(Commands.runOnce(drive::stopWithX, drive));
     testController.a().whileTrue(new ArmPIDTest(arm));


### PR DESCRIPTION
This allows movement straight left or straight right from the robot frame of reference.  So the driver can bump into the reef to align with it and then move left or right directly.

Also these can be useful for future autoscore.