### PR TITLE
Use getPosition rather than getHeight, fix ElevatorManual max height.

### DIFF
--- a/src/main/java/frc/robot/commands/ElevatorManual.java
+++ b/src/main/java/frc/robot/commands/ElevatorManual.java
@@ -64,7 +64,7 @@ public class ElevatorManual extends Command {
   @Override
   public boolean isFinished() {
     if (direction == Constants.Elevator.Direction.UP) {
-      return m_elevator.getHeight() >= limitUp;
+      return m_elevator.getPosition() >= limitUp;
     }
     return m_elevator.getPosition() <= limitDown;
   }


### PR DESCRIPTION
The ElevatorManual command was getting limited at the max height because it as calling 'getHeight' rather than getPosition.